### PR TITLE
Feature/automatically fix ecs errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           configuration: ./phpstan.neon
 
       - name: 🔬 Check ECS
-        run: src/vendor/bin/ecs check --ansi
+        run: src/vendor/bin/ecs check --ansi --fix --config ./ecs.php
 
       - name: Execute tests (Unit and Feature tests) via PestPHP
         run: vendor/bin/pest --coverage-clover clover.xml

--- a/src/composer.json
+++ b/src/composer.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "check-cs": "ecs check --ansi",
-    "fix-cs": "ecs check --ansi --fix",
+    "fix-cs": "ecs check --ansi --fix --config ../ecs.php",
     "phpstan": "vendor/bin/phpstan analyse",
     "post-root-package-install": [
       "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""


### PR DESCRIPTION
# Description

This PR makes 2 updates to the GH workflow:

1. It removes the use of `set-output`, which is deprecated (see https://github.com/zaengle/craft.comprehensibleclassroom.com/issues/127).
2. It updates the ECS check step to automatically fix any errors that are found.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)