### PR TITLE
Remove tailwind/forms. Add base and formie styles

### DIFF
--- a/package.json.tpl
+++ b/package.json.tpl
@@ -20,7 +20,6 @@
   },
   "homepage": "<% project.repoUrl %>#README.md",
   "dependencies": {
-    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.0.9",
     "dotenv": "^16.4.7",

--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -1,3 +1,10 @@
-@import "./vendor.css";
-
 @import "tailwindcss";
+
+@theme {
+  --color-primary-50: #dbeafe;
+  --color-primary-300: #3b82f6;
+}
+
+@import "./base.css";
+@import "./vendor.css";
+@import "./formie.css";

--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 @theme {
   --color-primary-50: #dbeafe;

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -1,0 +1,93 @@
+@layer base {
+  html {
+    @apply motion-safe:scroll-smooth;
+  }
+
+  ::selection {
+    @apply text-primary-50 bg-primary-300;
+  }
+  
+  a,
+  button {
+    @apply transition-colors duration-300 ease-in-out;
+  }
+
+  label {
+    @apply text-gray-800 font-semibold text-sm mb-1 block;
+  }
+
+  [type='tel'],
+  [type='url'],
+  [type='date'],
+  [type='text'],
+  [type='time'],
+  [type='week'],
+  [type='email'],
+  [type='month'],
+  [type='number'],
+  [type='search'],
+  [type='datetime'],
+  [type='password'],
+  [type='datetime-local'],
+  [multiple],
+  select,
+  textarea {
+    @apply
+      w-full
+      py-3 px-4
+      bg-gray-50 text-gray-800 text-base placeholder-gray-500
+      rounded-sm border border-gray-500
+      disabled:bg-gray-200 disabled:border-gray-500 disabled:text-gray-600 disabled:cursor-not-allowed
+      focus-visible:outline focus-visible:outline-offset-4 focus-visible:outline-primary-300
+      focus:ring-0 focus:ring-transparent focus:border-2 focus:border-gray-800
+    ;
+  }
+
+  [type='tel']:disabled,
+  [type='url']:disabled,
+  [type='date']:disabled,
+  [type='text']:disabled,
+  [type='time']:disabled,
+  [type='week']:disabled,
+  [type='email']:disabled,
+  [type='month']:disabled,
+  [type='number']:disabled,
+  [type='search']:disabled,
+  [type='checkbox']:disabled,
+  [type='datetime']:disabled,
+  [type='password']:disabled,
+  [type='datetime-local']:disabled,
+  [multiple]:disabled,
+  select:disabled,
+  textarea:disabled {
+    @apply
+      bg-gray-200
+      border-gray-500
+      text-gray-600
+      cursor-not-allowed
+    ;
+  }
+
+  [type='checkbox'] {
+    @apply rounded-sm;
+  }
+
+  [type='radio'],
+  [type='checkbox'] {
+    @apply
+      size-6
+      text-blue-500
+      border-gray-800
+      focus-visible:outline focus-visible:outline-offset-4 focus-visible:outline-primary-300
+      focus:ring-0 focus:ring-transparent focus:border-2 focus:border-gray-800
+    ;
+  }
+
+  select {
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23131313%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-position: right 1rem top 50%;
+    background-size: 0.65rem auto;
+  }
+}

--- a/src/assets/css/formie.css
+++ b/src/assets/css/formie.css
@@ -1,0 +1,89 @@
+/* @todo: Update Formie variables */
+.fui-i {
+  /* General */
+  --fui-font: inherit;
+  --fui-font-size: 16px;
+  --fui-color: var(--color-gray-800);
+  --fui-primary-color: var(--color-primary-300);
+  --fui-primary-color-hover: var(--color-primary-300);
+  --fui-error: var(--color-red-400);
+  --fui-success: var(--color-green-400);
+  --fui-gray-50: var(--color-gray-50);
+  --fui-gray-100: var(--color-gray-100);
+  --fui-gray-200: var(--color-gray-200);
+  --fui-gray-300: var(--color-gray-300);
+  --fui-gray-400: var(--color-gray-400);
+  --fui-gray-500: var(--color-gray-500);
+  --fui-gray-600: var(--color-gray-600);
+  --fui-gray-700: var(--color-gray-700);
+  --fui-gray-800: var(--color-gray-800);
+  --fui-gray-900: var(--color-gray-900);
+
+  --fui-border: 0 solid var(--fui-gray-500);
+  --fui-border-radius: 0.25rem;
+  --fui-border-color: var(--fui-gray-500);
+  --fui-focus-border-color: var(--fui-gray-800);
+  --fui-focus-shadow: none;
+
+  /* Alerts*/
+  --fui-alert-error-bg-color: var(--color-red-100);
+  --fui-alert-error-color: var(--fui-gray-800);
+  --fui-alert-success-bg-color: var(--color-green-100);
+  --fui-alert-success-color: var(--fui-gray-800);
+  --fui-alert-border-radius: 0;
+
+  /* Field Labels*/
+  --fui-label-font-weight: 600;
+  --fui-label-font-size: 0.875rem;
+  --fui-label-line-height: 1.25;
+  --fui-label-error-color: var(--fui-gray-800);
+  --fui-label-error-border-color: var(--color-red-400);
+
+  /* Field - Checkboxes/Radios*/
+  --fui-check-bg-color: var(--fui-gray-50)
+  --fui-check-label-height: 1.5rem!;
+  --fui-check-label-width: 1.5rem!;
+
+  /* Field - Input*/
+  --fui-input-font-size: 1rem;
+  --fui-input-line-height: 1.5rem;
+  --fui-input-padding: 0.75rem 1rem;
+  --fui-input-background-color: var(--fui-gray-50)
+  --fui-input-error-color: var(--color-red-400);
+  --fui-input-error-border-color: var(--color-red-400);
+  --fui-input-error-box-shadow-focus: none;
+  --fui-input-placeholder-color: var(--fui-gray-500);
+  --fui-input-border: 0.5px solid var(--fui-gray-500);
+
+  /* Field - Button*/
+  --fui-submit-btn-bg-color: var(--color-primary-300);
+  --fui-submit-btn-color: var(--color-white);
+
+  .fui-alert {
+    @apply border-l-4;
+
+    &.fui-alert-error {
+      @apply border-red-400 bg-red-50 text-gray-800;
+    }
+
+    &.fui-alert-success {
+      @apply border-green-400 bg-green-50 text-gray-800;
+    }
+  }
+
+  .fui-error-message {
+    @apply text-sm;
+  }
+
+  /* @todo apply button styles */
+  .fui-btn {
+  }
+
+  .fui-checkbox:focus-within, .fui-radio:focus-within {
+    @apply outline outline-offset-4 outline-primary-300;
+  }
+
+  .fui-checkbox label, .fui-radio label {
+    @apply pt-1;
+  }
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,3 @@
-import debugScreens from 'tailwindcss-debug-screens'
-import typography from '@tailwindcss/typography'
-
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -13,8 +10,4 @@ export default {
       colors: (theme) => ({}),
     },
   },
-  plugins: [
-    debugScreens,
-    typography,
-  ],
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,5 @@
 import debugScreens from 'tailwindcss-debug-screens'
 import typography from '@tailwindcss/typography'
-import forms from '@tailwindcss/forms'
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -17,6 +16,5 @@ export default {
   plugins: [
     debugScreens,
     typography,
-    forms,
   ],
 }


### PR DESCRIPTION
# Description

Removed the @tailwind/forms plugin and added basic styles to the `assets/css` folder. 

The styles should pull colors from the Tailwind default other than the `primary` color. I left that as a nudge to update the primary color and button style but can remove if needed.

**Note**: I had trouble getting the baseline site set up locally using the updated branch. It would fail at the Craft install step every time with an error that it couldn't write to the `.env` file. I was able to fix by re-adding the `config/project` files from the `main` branch.