### PR TITLE
#188: add npm security hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package.json.tpl
+++ b/package.json.tpl
@@ -41,5 +41,11 @@
     "vite-plugin-svg-icons": "^2.0.1",
     "vitepress": "^1.2.0",
     "vitest": "^3.1.4"
+  },
+  "optionalDependencies": {
+    "@esbuild/darwin-arm64": "^0.27.0",
+    "@esbuild/darwin-x64": "^0.27.0",
+    "@esbuild/linux-x64": "^0.27.0",
+    "@esbuild/linux-arm64": "^0.27.0"
   }
 }


### PR DESCRIPTION
# Description

Adds `.npmrc` with `ignore-scripts` turned on and Linux support in the `package.json.tpl`.

Fixes: #188 

